### PR TITLE
Fix for React Native 44+

### DIFF
--- a/components/ConfirmationCodeInput.js
+++ b/components/ConfirmationCodeInput.js
@@ -20,7 +20,7 @@ export default class ConfirmationCodeInput extends Component {
     ignoreCase: PropTypes.bool,
     autoFocus: PropTypes.bool,
     codeInputStyle: TextInput.propTypes.style,
-    containerStyle: ViewPropTypes.style,
+    containerStyle: viewPropTypes.style,
     onFulfill: PropTypes.func,
   };
   

--- a/components/ConfirmationCodeInput.js
+++ b/components/ConfirmationCodeInput.js
@@ -1,7 +1,10 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import { View, TextInput, StyleSheet, Dimensions } from 'react-native';
+import { View, TextInput, StyleSheet, Dimensions, ViewPropTypes } from 'react-native';
 import _ from 'lodash';
+
+// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
+const viewPropTypes = ViewPropTypes || View.propTypes;
 
 export default class ConfirmationCodeInput extends Component {
   static propTypes = {
@@ -17,7 +20,7 @@ export default class ConfirmationCodeInput extends Component {
     ignoreCase: PropTypes.bool,
     autoFocus: PropTypes.bool,
     codeInputStyle: TextInput.propTypes.style,
-    containerStyle: View.propTypes.style,
+    containerStyle: ViewPropTypes.style,
     onFulfill: PropTypes.func,
   };
   


### PR DESCRIPTION
I encountered this exception after deploying a build to TestFlight with your library.

`Terminating app due to uncaught exception 'RCTFatalException: Unhandled JS Exception: undefined is not an object (evaluating 'u.View.propTypes.style')', reason: 'Unhandled JS Exception: undefined is not an object (evaluating 'u.View.prop..., stack:`

This fixes the problem for me, and hopefully doesn't break RN <44.