### PR TITLE
onChangeCode callback and defaultCode props added. Readme updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ Prop       | Type    | Default    | Description
 `inactiveColor`     | string   | `rgba(255, 255, 255, 0.2)` | color of cells when inactive
 `ignoreCase`        | boolean  | `false`      | ignore case when checking code
 `autoFocus`         | boolean  | `true`       | auto focus on code input
+`defaultCode`       | string   |              | initial value for code inputs. Set `autoFocus` to `false` when using `defaultCode`
 `codeInputStyle`    | style object   |        | custom style for code input
 `containerStyle`    | style object   |        | custom style for code input container
+`onChangeCode`      | function |              | callback function called when any of the input value is changed. Always returns last `(code)` in callback.
 `onFulfill`         | function |              | callback function called when fulfilling code. If `compareWithCode` is null -> return `(code)` in callback, else return `(isValid, code)`. **Required**
 
 ## functions

--- a/components/ConfirmationCodeInput.js
+++ b/components/ConfirmationCodeInput.js
@@ -22,6 +22,8 @@ export default class ConfirmationCodeInput extends Component {
     codeInputStyle: TextInput.propTypes.style,
     containerStyle: viewPropTypes.style,
     onFulfill: PropTypes.func,
+    onChangeCode: PropTypes.func,
+    defaultCode: PropTypes.string,
   };
   
   static defaultProps = {
@@ -35,7 +37,8 @@ export default class ConfirmationCodeInput extends Component {
     inactiveColor: 'rgba(255, 255, 255, 0.2)',
     space: 8,
     compareWithCode: '',
-    ignoreCase: false
+    ignoreCase: false,
+    defaultCode: '',
   };
   
   constructor(props) {
@@ -50,13 +53,22 @@ export default class ConfirmationCodeInput extends Component {
   }
   
   componentDidMount() {
-    const { compareWithCode, codeLength, inputPosition } = this.props;
+    const { compareWithCode, codeLength, inputPosition, defaultCode } = this.props;
     if (compareWithCode && compareWithCode.length !== codeLength) {
       console.error("Invalid props: compareWith length is not equal to codeLength");
     }
     
     if (_.indexOf(['center', 'left', 'right', 'full-width'], inputPosition) === -1) {
       console.error('Invalid input position. Must be in: center, left, right, full');
+    }
+
+    if (defaultCode && defaultCode.length !== codeLength) {
+      console.error("Invalid props: defaultCode length is not equal to codeLength");
+    }
+    else {
+      this.setState({
+        codeArr: _.split(defaultCode, '')
+      });
     }
   }
   
@@ -77,6 +89,8 @@ export default class ConfirmationCodeInput extends Component {
   }
   
   _onFocus(index) {
+    const { onChangeCode } = this.props;
+
     let newCodeArr = _.clone(this.state.codeArr);
     const currentEmptyIndex = _.findIndex(newCodeArr, c => !c);
     if (currentEmptyIndex !== -1 && currentEmptyIndex < index) {
@@ -86,6 +100,10 @@ export default class ConfirmationCodeInput extends Component {
       if (i >= index) {
         newCodeArr[i] = '';
       }
+    }
+
+    if (onChangeCode) {
+      onChangeCode(newCodeArr.join(''));
     }
     
     this.setState({
@@ -202,7 +220,7 @@ export default class ConfirmationCodeInput extends Component {
   }
   
   _onInputCode(character, index) {
-    const { codeLength, onFulfill, compareWithCode, ignoreCase } = this.props;
+    const { codeLength, onFulfill, compareWithCode, ignoreCase, onChangeCode } = this.props;
     let newCodeArr = _.clone(this.state.codeArr);
     newCodeArr[index] = character;
     
@@ -217,6 +235,11 @@ export default class ConfirmationCodeInput extends Component {
         onFulfill(code);
       }
       this._blur(this.state.currentIndex);
+
+      if (onChangeCode) {
+        onChangeCode(code);
+      }
+
     } else {
       this._setFocus(this.state.currentIndex + 1);
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,9 +17,11 @@ declare module "react-native-confirmation-code-input" {
         activeColor?: string;
         inactiveColor?: string;
         ignoreCase?: boolean;
-        codeInputStyle?: any,
+        codeInputStyle?: any;
         containerStyle?: any;
         onFulfill: Function;
+        onChangeCode?: Function;
+        defaultCode?: string;
     }
 
     export default class CodeInput extends React.Component<CodeInputProps, any> { }


### PR DESCRIPTION
Added a callback function `onChangeCode` that will return the last input `code` every time a value is changed. Added a new props `defaultCode` which will set the initial value for the code inputs. `defaultCode` must be used with `autoFocus` set to `false` as this overrides the focus for inputs.